### PR TITLE
Rearrange readme and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,21 @@
-bindhosts
-
+## bindhosts
 Systemless hosts for Apatch, KernelSU and Magisk
 
-  1.4.2 - 1.6.3
-   - custom rules, modifiable sources, blacklist and whitelist support
-   - optimizations and check for other downloaders
-   - detect user changes, fix localhost bug
-   - leverage skip mount, migrate to compat
-   - Adaway coexistence handling
-   - fixups: whitelist processing, rare update failures
-   - /data/adb/bindhosts migration  
-   - webui on supported managers - KOWX712
-   - small fixups
-    
-  1.6.5-dev
-   - unify two codebases, ahemm scriptbases
-   - development version, need testers
-   - fixups on that operating_mode system
-    
+---
+
+# Changelog
+### 1.6.5-dev
+- unify two codebases, ahemm scriptbases
+- development version, need testers
+- fixups on that operating_mode system
+
+### 1.4.2 - 1.6.3
+- custom rules, modifiable sources, blacklist and whitelist support
+- optimizations and check for other downloaders
+- detect user changes, fix localhost bug
+- leverage skip mount, migrate to compat
+- Adaway coexistence handling
+- fixups: whitelist processing, rare update failures
+- /data/adb/bindhosts migration  
+- webui on supported managers - KOWX712
+- small fixups

--- a/Documentation/CHANGELOG_FULL.md
+++ b/Documentation/CHANGELOG_FULL.md
@@ -1,98 +1,98 @@
-bindhosts
-
+## bindhosts
 Systemless hosts for Apatch, KernelSU and Magisk
-  
-1.2.0
- - squash everything?
- - initial
-  
-1.2.1
- - you dont even need to reboot now (customize.sh)
- - copies old hosts file on update
-   
-1.2.5
- - fix issue where hosts file doesnt exist on reboot after fresh install
 
-1.3.3
-  - fix magisk support
-   
-1.3.4
- - hardcode moddir  
+---
 
-1.3.5
- - spoof last modified time  
+# Changelog
+### 1.7.x ?
+- implement operating modes
+- unify codebases (scriptbases? on such case)
 
-1.3.6
- - 644 -> 600 on hosts file permission (better hide)
+### 1.6.3s / 1.6.3c
+- small fixups 
 
-1.3.7
- - restore old behavior, cancel 1.3.5 and 1.3.6 changes
+### 1.6.0s / 1.6.0c
+- WebUI on supported managers - c/o KOWX712
 
-1.3.8
- - disable and copy old hosts file from other modules too
+### 1.5.6s / 1.5.6c
+- /data/adb/bindhosts migration
 
-1.3.9
- - [susfs >= 1.1.0](https://gitlab.com/simonpunk/susfs4ksu) try_umount support added
+### 1.5.5s / 1.5.5c
+- hosuekeeping stuff / script optimizations / fixups
 
-1.4.0
- - [susfs](https://gitlab.com/simonpunk/susfs4ksu) modernize susfs support (tested at 1.3.8)
+### 1.5.4s / 1.5.4c
+- fixup rare update failures 
 
-1.4.1
- - simple action.sh demo
+### 1.5.3s / 1.5.3c
+- fixup! whitelist processing 
 
-1.4.2 ~ 1.4.3
- - extensive action.sh demo
- - sources, blacklist and whitelist support
- - optimize and check for other downloaders
-
-1.4.4
- - fully implemented standalone hosts-based-adblocking implementation
-
-1.4.5
- - detect user changes / state management, fix localhost bug
-
-1.4.6
- - leverage skip_mount, migrate to compat, migrate to standalone
- - codebase split here
-
-1.4.7s / 1.4.7c
- - fixup! apatch's environment detection
- 
-1.4.8s / 1.4.8c
- - account custom rules, misc housekeeping stuff
- 
-1.4.9s
-- implement [ZN-hostsredirect](https://github.com/aviraxp/ZN-hostsredirect) helper mode (requires zygisk next)
- 
-1.4.9c
- - Adaway coexistence handling
- 
-1.5.0s / 1.5.0c
- - misc cleanups, adjust rules a bit
-
-1.5.2s
+### 1.5.2s
 - implement [hosts_file_redirect](https://github.com/AndroidPatch/kpm/tree/main/src/hosts_file_redirect) helper mode
- 
-1.5.3s / 1.5.3c
- - fixup! whitelist processing 
- 
-1.5.4s / 1.5.4c
- - fixup rare update failures 
- 
-1.5.5s / 1.5.5c
- - hosuekeeping stuff / script optimizations / fixups
- 
-1.5.6s / 1.5.6c
- - /data/adb/bindhosts migration
 
-1.6.0s / 1.6.0c
- - WebUI on supported managers - c/o KOWX712
+### 1.5.0s / 1.5.0c
+- misc cleanups, adjust rules a bit
 
-1.6.3s / 1.6.3c
- - small fixups 
- 
-1.7.x ?
- - implement operating modes
- - unify codebases (scriptbases? on such case)
- 
- 
+### 1.4.9s
+- implement [ZN-hostsredirect](https://github.com/aviraxp/ZN-hostsredirect) helper mode (requires zygisk next)
+
+### 1.4.9c
+- Adaway coexistence handling
+
+### 1.4.8s / 1.4.8c
+- account custom rules, misc housekeeping stuff
+
+### 1.4.7s / 1.4.7c
+- fixup! apatch's environment detection
+
+### 1.4.6
+- leverage skip_mount, migrate to compat, migrate to standalone
+- codebase split here
+
+### 1.4.5
+- detect user changes / state management, fix localhost bug
+
+### 1.4.4
+- fully implemented standalone hosts-based-adblocking implementation
+
+### 1.4.2 ~ 1.4.3
+- extensive action.sh demo
+- sources, blacklist and whitelist support
+- optimize and check for other downloaders
+
+### 1.4.1
+- simple action.sh demo
+
+### 1.4.0
+- [susfs](https://gitlab.com/simonpunk/susfs4ksu) modernize susfs support (tested at 1.3.8)
+
+### 1.3.9
+- [susfs >= 1.1.0](https://gitlab.com/simonpunk/susfs4ksu) try_umount support added
+
+### 1.3.8
+- disable and copy old hosts file from other modules too
+
+### 1.3.7
+- restore old behavior, cancel 1.3.5 and 1.3.6 changes
+
+### 1.3.6
+- 644 -> 600 on hosts file permission (better hide)
+
+### 1.3.5
+- spoof last modified time
+
+### 1.3.4
+- hardcode moddir
+
+### 1.3.3
+- fix magisk support
+
+### 1.2.5
+- fix issue where hosts file doesnt exist on reboot after fresh install
+
+### 1.2.1
+- you dont even need to reboot now (customize.sh)
+- copies old hosts file on update
+
+### 1.2.0
+- squash everything?
+- initial

--- a/Documentation/modes.md
+++ b/Documentation/modes.md
@@ -4,7 +4,7 @@
 ---
 
 ## mode=0
-- **default mode**
+### default mode
  - **APatch** - OverlayFS / magic mount?
    - magic mount is Adaway compatible ?
    - Hiding: none at all  
@@ -18,7 +18,7 @@
 ---
 
 ## mode=1
-- **ksu_susfs_bind mode**
+### ksu_susfs_bind mode
 - KernelSU only  
 - Requires susfs-patched kernel and userspace tool  
 - Adaway compatible  
@@ -27,7 +27,7 @@
 ---
 
 ## mode=2
-- **plain bindhosts**
+### plain bindhosts
 - mount --bind
 - Actually works on all managers, but not really preferable as it leaks the global mount  
 - only useful as a last resort, only available as opt-in
@@ -37,7 +37,7 @@
 ---
 
 ## mode=3
-- **apatch_hfr, hosts_file_redirect**
+### apatch_hfr, hosts_file_redirect
 - in-kernel redirection of /system/etc/hosts for uid 0
 - APatch only, requires hosts_file_redirect KPM  
   - [hosts_file_redirect](https://github.com/AndroidPatch/kpm/blob/main/src/hosts_file_redirect/)  
@@ -49,7 +49,7 @@
 ---
 
 ## mode=4
-- **zn_hostsredirect**
+### zn_hostsredirect
 - zygisk netd injection
 - should work on all managers  
 - Requires:  
@@ -61,7 +61,7 @@
 ---
 
 ## mode=5
-- **ksu_susfs_open_redirect**
+### ksu_susfs_open_redirect
 - in-kernel file redirects for uid <2000
 - KernelSU only 
 - **OPT-IN** only 
@@ -74,7 +74,7 @@
 ---
 
 ## mode=6: 
-- **ksu_source_mod**
+### ksu_source_mod
 - KernelSU only  
 - **OPT-IN** only 
 - Requires source modification: [reference](https://github.com/tiann/KernelSU/commit/2b2b0733d7c57324b742c017c302fc2c411fe0eb)  

--- a/README.md
+++ b/README.md
@@ -5,26 +5,27 @@ Systemless hosts for Apatch, KernelSU and Magisk
 Fully standalone, self-updating.
 
 ## Features
- - action button control
- - WebUI control
- - both Adaway coexistence (on certain modes)
- - injection and redirect modes (znhr, hfr, open_redirect)
- - whatever brah just try
+- Action button control
+- WebUI control
+- Both Adaway coexistence (on certain modes)
+- Injection and redirect modes (znhr, hfr, open_redirect)
+- Whatever branch just try
 
-Supports following root managers:
- - [APatch](https://github.com/bmax121/APatch)
- - [KernelSU](https://github.com/tiann/KernelSU)
- - [Magisk](https://github.com/topjohnwu/Magisk) + [KsuWebUI](https://github.com/5ec1cff/KsuWebUIStandalone)
- 
-Operating Modes
- - [read modes.md](https://github.com/backslashxx/bindhosts/blob/dev/unified/Documentation/modes.md)
+## Supported Root Managers
+- [APatch](https://github.com/bmax121/APatch)
+- [KernelSU](https://github.com/tiann/KernelSU)
+- [Magisk](https://github.com/topjohnwu/Magisk) + [KsuWebUI](https://github.com/5ec1cff/KsuWebUIStandalone)
 
-Hiding: 
- - read modes.md for now, will add later
+## Operating Modes
+- Read [bindhosts operation modes](https://github.com/backslashxx/bindhosts/blob/dev/unified/Documentation/modes.md).
 
-  
-[Download](https://raw.githubusercontent.com/backslashxx/bindhosts/staging/module.zip)
+## Hiding
+- read modes.md for now, will add later
 
-[report for any issues](https://github.com/backslashxx/bindhosts/issues)
+## Links
+Download [here](https://raw.githubusercontent.com/backslashxx/bindhosts/staging/module.zip)
 
-[Pull requests welcome](https://github.com/backslashxx/bindhosts/pulls)
+## Help and Support
+Report [here](https://github.com/backslashxx/bindhosts/issues) if you encounter any issues.
+
+[Pull requests](https://github.com/backslashxx/bindhosts/pulls) are always welcome.


### PR DESCRIPTION
Readme: Minor ui change. Changelog: move newer changelog up because root manager show changelog from up to down.

## Preview: 
- [README.md](https://github.com/KOWX712/bindhosts/blob/readme_changelog/README.md)
- [CHANGELOG.md](https://github.com/KOWX712/bindhosts/blob/readme_changelog/CHANGELOG.md)
- [CHANGLOG_FULL.md](https://github.com/KOWX712/bindhosts/blob/readme_changelog/Documentation/CHANGELOG_FULL.md)
- [modes.md](https://github.com/KOWX712/bindhosts/blob/readme_changelog/Documentation/modes.md)