### PR TITLE
webui: mode button triggers dev settings

### DIFF
--- a/module/webroot/index.html
+++ b/module/webroot/index.html
@@ -13,8 +13,7 @@
 <body>
 	<div class="header">
 		<div id="title">bindhosts <span id="version-text"></span></div>
-		<a href="https://github.com/backslashxx/bindhosts/blob/master/Documentation/modes.md#bindhosts-operating-modes"
-			class="current-mode-text">Mode: <span id="mode-text">X</span></a>
+		<div id="mode-btn" class="current-mode-text">Mode: <span id="mode-text">X</span></div>
 	</div>
 	<div class="content">
 		<div class="float">

--- a/module/webroot/index.js
+++ b/module/webroot/index.js
@@ -9,6 +9,7 @@ const filePaths = {
 
 let clickCount = 0;
 let timeout;
+let clickTimeout;
 let developerOption = false;
 let disableTimeout;
 
@@ -228,9 +229,17 @@ document.getElementById("mode-btn").addEventListener("click", async () => {
 document.getElementById("status-box").addEventListener("click", async () => {
     clickCount++;
 
+    // Reset the timeout on each click to prevent automatic reset if user keeps clicking
+    clearTimeout(clickTimeout);
+
+    // Set a new timeout to reset the count after a 2-second delay (adjust if needed)
+    clickTimeout = setTimeout(() => {
+        clickCount = 0;
+    }, 2000); // 2 seconds
+
     // Only handle after 5 clicks
     if (clickCount === 5) {
-        // Reset click count
+        // Reset click count after 5 clicks
         clickCount = 0;
 
         // Only handle if developer option is not enabled yet

--- a/module/webroot/index.js
+++ b/module/webroot/index.js
@@ -205,7 +205,7 @@ async function executeActionScript() {
 }
 
 // Open mode menu with developer option logic
-document.getElementById("status-box").addEventListener("click", async () => {
+document.getElementById("mode-btn").addEventListener("click", async () => {
     if (developerOption) {
         await updateModeSelection();
         openOverlay(document.getElementById("mode-menu"));

--- a/module/webroot/index.js
+++ b/module/webroot/index.js
@@ -7,6 +7,7 @@ const filePaths = {
     whitelist: `${basePath}/whitelist.txt`,
 };
 
+let clickCount = 0;
 let timeout;
 let developerOption = false;
 let disableTimeout;
@@ -224,23 +225,19 @@ document.getElementById("mode-btn").addEventListener("click", async () => {
     }
 });
 
-document.getElementById("mode-btn").addEventListener("dblclick", async () => {
-    // Only handle double tap if developer option is not enabled yet
-    if (!developerOption) {
-        const fileExists = await execCommand("[ -f /data/adb/bindhosts/mode_override.sh ] && echo 'exists' || echo 'not-exists'");
-        
-        if (fileExists.trim() === "exists") {
-            developerOption = true;
-            showPrompt("Developer option enabled", true);
-            openOverlay(document.getElementById("mode-menu"));
-            // Set a timeout to automatically disable developer option after 20 seconds
-            disableTimeout = setTimeout(() => {
-                developerOption = false;
-                showPrompt("Developer option disabled", false);
-            }, 20000); // 20 seconds
-        } else {
-            try {
-                await execCommand("> /data/adb/bindhosts/mode_override.sh");
+document.getElementById("status-box").addEventListener("click", async () => {
+    clickCount++;
+
+    // Only handle after 5 clicks
+    if (clickCount === 5) {
+        // Reset click count
+        clickCount = 0;
+
+        // Only handle if developer option is not enabled yet
+        if (!developerOption) {
+            const fileExists = await execCommand("[ -f /data/adb/bindhosts/mode_override.sh ] && echo 'exists' || echo 'not-exists'");
+            
+            if (fileExists.trim() === "exists") {
                 developerOption = true;
                 showPrompt("Developer option enabled", true);
                 openOverlay(document.getElementById("mode-menu"));
@@ -249,9 +246,21 @@ document.getElementById("mode-btn").addEventListener("dblclick", async () => {
                     developerOption = false;
                     showPrompt("Developer option disabled", false);
                 }, 20000); // 20 seconds
-            } catch (error) {
-                console.error("Error enabling developer option:", error);
-                showPrompt("Error enabling developer option", false);
+            } else {
+                try {
+                    await execCommand("> /data/adb/bindhosts/mode_override.sh");
+                    developerOption = true;
+                    showPrompt("Developer option enabled", true);
+                    openOverlay(document.getElementById("mode-menu"));
+                    // Set a timeout to automatically disable developer option after 20 seconds
+                    disableTimeout = setTimeout(() => {
+                        developerOption = false;
+                        showPrompt("Developer option disabled", false);
+                    }, 20000); // 20 seconds
+                } catch (error) {
+                    console.error("Error enabling developer option:", error);
+                    showPrompt("Error enabling developer option", false);
+                }
             }
         }
     }

--- a/module/webroot/index.js
+++ b/module/webroot/index.js
@@ -249,7 +249,7 @@ document.getElementById("status-box").addEventListener("click", async () => {
             if (fileExists.trim() === "exists") {
                 developerOption = true;
                 showPrompt("Developer option enabled", true);
-                openOverlay(document.getElementById("mode-menu"));
+                
                 // Set a timeout to automatically disable developer option after 20 seconds
                 disableTimeout = setTimeout(() => {
                     developerOption = false;
@@ -260,7 +260,7 @@ document.getElementById("status-box").addEventListener("click", async () => {
                     await execCommand("> /data/adb/bindhosts/mode_override.sh");
                     developerOption = true;
                     showPrompt("Developer option enabled", true);
-                    openOverlay(document.getElementById("mode-menu"));
+                    
                     // Set a timeout to automatically disable developer option after 20 seconds
                     disableTimeout = setTimeout(() => {
                         developerOption = false;


### PR DESCRIPTION
Removed operation documentation from header mode button since you can just do the same from dev settings and change dev settings trigger from status-box to mode-btn, seems more logical imo