### PR TITLE
bindhosts speed improvements

### DIFF
--- a/module/bindhosts.sh
+++ b/module/bindhosts.sh
@@ -126,14 +126,14 @@ sort_cmd() {
 adblock() {
 	# source processing start!
 	echo "[+] processing sources"
-	grep -v "#" $PERSISTENT_DIR/sources.txt | grep http > /dev/null || {
+	sed '/#/d' $PERSISTENT_DIR/sources.txt | grep http > /dev/null || {
 			echo "[x] no sources found 😭" 
 			echo "[x] sources.txt needs correction 💢"
 			return
 			}
 	illusion
         # download routine start!
-	for url in $(grep -v "#" $PERSISTENT_DIR/sources.txt | grep http) ; do 
+	for url in $(sed '/#/d' $PERSISTENT_DIR/sources.txt | grep http) ; do 
 		echo "[+] grabbing.."
 		echo "[>] $url"
 		download "$url" >> $folder/temphosts || echo "[x] failed downloading $url"
@@ -150,16 +150,16 @@ adblock() {
 	# localhost
 	printf "127.0.0.1 localhost\n::1 localhost\n" > $target_hostsfile
 	# always restore user's custom rules
-	grep -v "#" $PERSISTENT_DIR/custom.txt >> $target_hostsfile
+	sed '/#/d' $PERSISTENT_DIR/custom.txt >> $target_hostsfile
 	# blacklist.txt
-	for i in $(grep -v "#" $PERSISTENT_DIR/blacklist.txt ); do echo "0.0.0.0 $i" >> $folder/temphosts; done
+	for i in $(sed '/#/d' $PERSISTENT_DIR/blacklist.txt ); do echo "0.0.0.0 $i" >> $folder/temphosts; done
 	# whitelist.txt
 	echo "[+] processing whitelist"
 	# make sure tempwhitelist isnt empty
 	# or it will grep out nothingness from everything
 	# which actually greps out everything.
 	echo "256.256.256.256 bindhosts" > $folder/tempwhitelist
-	for i in $(grep -v "#" $PERSISTENT_DIR/whitelist.txt); do echo "0.0.0.0 $i" ; done >> $folder/tempwhitelist
+	for i in $(sed '/#/d' $PERSISTENT_DIR/whitelist.txt); do echo "0.0.0.0 $i" ; done >> $folder/tempwhitelist
 	# sed strip out everything with #, double space to single space, replace all 127.0.0.1 to 0.0.0.0
 	# then sort uniq, then grep out whitelist.txt from it
 	sed -i '/#/d; s/  / /g; /^$/d; s/127.0.0.1/0.0.0.0/' $folder/temphosts
@@ -173,7 +173,7 @@ reset() {
 	# localhost
 	printf "127.0.0.1 localhost\n::1 localhost\n" > $target_hostsfile
 	# always restore user's custom rules
-	grep -v "#" $PERSISTENT_DIR/custom.txt >> $target_hostsfile
+	sed '/#/d' $PERSISTENT_DIR/custom.txt >> $target_hostsfile
         string="description=status: reset 🤐 | $(date)"
         sed -i "s/^description=.*/$string/g" $MODDIR/module.prop
         illusion

--- a/module/bindhosts.sh
+++ b/module/bindhosts.sh
@@ -162,8 +162,8 @@ adblock() {
 	for i in $(sed '/#/d' $PERSISTENT_DIR/whitelist.txt); do echo "0.0.0.0 $i" ; done >> $folder/tempwhitelist
 	# sed strip out everything with #, double space to single space, replace all 127.0.0.1 to 0.0.0.0
 	# then sort uniq, then grep out whitelist.txt from it
-	sed -i '/#/d; s/  / /g; /^$/d; s/127.0.0.1/0.0.0.0/' $folder/temphosts
-	sort_cmd "$folder/temphosts" | grep -Fxvf $folder/tempwhitelist | busybox dos2unix >> $target_hostsfile
+	sed -i '/#/d; s/  / /g; /^$/d; s/\r$//; s/127.0.0.1/0.0.0.0/' $folder/temphosts
+	sort_cmd "$folder/temphosts" | grep -Fxvf $folder/tempwhitelist >> $target_hostsfile
 	# mark it, will be read by service.sh to deduce
 	echo "# bindhosts v$versionCode" >> $target_hostsfile
 }

--- a/module/bindhosts.sh
+++ b/module/bindhosts.sh
@@ -7,6 +7,8 @@ PERSISTENT_DIR="/data/adb/bindhosts"
 # bindhosts.sh
 # bindhosts' processing backend
 
+nproc=$(busybox nproc)
+
 # grab own info (version)
 versionCode=$(grep versionCode $MODDIR/module.prop | sed 's/versionCode=//g' )
 
@@ -113,6 +115,14 @@ download() {
         fi
 }        
 
+sort_cmd() {
+	if [ -f /data/data/com.termux/files/usr/bin/sort ]; then
+		/data/data/com.termux/files/usr/bin/sort --parallel=$nproc -u $1
+    else
+		sort -u $1
+    fi
+}
+
 adblock() {
 	# source processing start!
 	echo "[+] processing sources"
@@ -152,7 +162,8 @@ adblock() {
 	for i in $(grep -v "#" $PERSISTENT_DIR/whitelist.txt); do echo "0.0.0.0 $i" ; done >> $folder/tempwhitelist
 	# sed strip out everything with #, double space to single space, replace all 127.0.0.1 to 0.0.0.0
 	# then sort uniq, then grep out whitelist.txt from it
-	sed '/#/d; s/  / /g; /^$/d; s/127.0.0.1/0.0.0.0/' $folder/temphosts | sort -u | grep -Fxvf $folder/tempwhitelist | busybox dos2unix >> $target_hostsfile
+	sed -i '/#/d; s/  / /g; /^$/d; s/127.0.0.1/0.0.0.0/' $folder/temphosts
+	sort_cmd "$folder/temphosts" | grep -Fxvf $folder/tempwhitelist | busybox dos2unix >> $target_hostsfile
 	# mark it, will be read by service.sh to deduce
 	echo "# bindhosts v$versionCode" >> $target_hostsfile
 }


### PR DESCRIPTION
- Use coreutils binary from termux for parallel sorting if
available.
- Modify temphosts instead of piping to take advantage of cache
prediction.
- Replace `grep` with `sed` when possible.
- Replace `dos2unix` with `sed`.