### PR TITLE
workflows: execlude documentation changes from workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '.github/workflows/release.yml'
+      - 'module/**'
+      - 'update.json'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Let's build the module when there's an actual commit into module files