### PR TITLE
bindhost tile shortcut

### DIFF
--- a/module/bindhosts-app.sh
+++ b/module/bindhosts-app.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+PATH=/data/adb/ap/bin:/data/adb/ksu/bin:/data/adb/magisk:/data/data/com.termux/files/usr/bin:$PATH
+# Replace with your repository details
+REPO_OWNER="itejo443"
+REPO_NAME="BindHosts-app"
+
+# App package name
+APP_PACKAGE="me.itejo443.bindhosts"
+
+# Temporary directory to store the APK
+TEMP_DIR="/data/local/tmp/bindhosts-app"
+APK_PATH="$TEMP_DIR/app.apk"
+
+# Directory to save the APK if devpts hooks fail
+FAILSAFE_DIR="/sdcard/download/bindhosts-app"
+FAILSAFE_PATH="$FAILSAFE_DIR/app.apk"
+
+# Create necessary directories
+mkdir -p "$TEMP_DIR"
+mkdir -p "$FAILSAFE_DIR"
+
+download() {
+	if command -v curl > /dev/null 2>&1; then
+		curl --connect-timeout 10 -Ls "$1"
+        else
+		busybox wget -T 10 --no-check-certificate -qO - "$1"
+        fi
+}    
+
+# Get the latest release URL using curl, grep, and sed
+latest_release_url=$(download "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/latest" \
+    | grep '"browser_download_url":' \
+    | sed -E 's/.*"browser_download_url": "(.*\.apk)".*/\1/')
+
+# Check if the URL is valid
+if [ -z "$latest_release_url" ]; then
+    echo "Error: Could not find a latest release URL."
+    exit 1
+fi
+
+echo "Latest APK URL: $latest_release_url"
+
+# Download the APK file using download()
+download "$latest_release_url" > "$APK_PATH" 
+
+# Check if the download was successful
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to download the APK. Exiting."
+    exit 1
+fi
+
+# Install the APK as a user app
+pm install -r "$APK_PATH"
+
+# Check if the installation was successful by verifying the app's presence
+pm list packages | grep "$APP_PACKAGE" > /dev/null
+
+if [ $? -eq 0 ]; then
+    echo "APK installed successfully as a user app."
+    echo "[+] BindHosts-app Installed"
+    echo "[+] Enable SU with Capabilities"
+    echo "[+] Enable Tile Bindhosts-app Tile && Notification Permission"
+else
+    echo "Error: devpts hooks failed (pm commands issue). Saving APK to failsafe location."
+    
+    # Save the APK to the failsafe directory if devpts hooks fail
+    cp "$APK_PATH" "$FAILSAFE_PATH"
+    
+    echo "[+] Please Install app from sdcard/download/bindhosts-app"
+fi
+
+# Clean up
+rm -rf "$TEMP_DIR"

--- a/module/bindhosts.sh
+++ b/module/bindhosts.sh
@@ -461,31 +461,6 @@ tcpdump () {
 	fi
 }
 
-bindhosts_app () {
-        echo "[+] Installing BindHosts-app..."
-        
-        # Check if the script exists before running it
-        if [ -f "/data/adb/modules/bindhosts/bindhosts-app.sh" ]; then
-        	su -c "sh /data/adb/modules/bindhosts/bindhosts-app.sh"
-        else
-        	echo "[-] bindhosts-app.sh not found!"
-        fi
-}
-
-bindhosts_app_uninstall () {
-        echo "[+] Checking if the package 'me.itejo443.bindhosts' is installed..."
-        echo "[!] If you don't have devpts hooks, then please uninstall manually ..."
-
-        # Check if the package is installed
-        if pm list packages | grep -q "me.itejo443.bindhosts"; then
-        	echo "[+] Package found. Uninstalling..."
-        	# Uninstall the package
-        	su -c "pm uninstall me.itejo443.bindhosts"
-        else
-        	echo "[-] Package 'me.itejo443.bindhosts' not found. Skipping..."
-        fi
-}
-
 show_help () {
 	echo "[%] $( grep '^description=' $MODDIR/module.prop | sed 's/description=//' )"
 	echo "usage:"
@@ -493,8 +468,6 @@ show_help () {
 	printf " --tcpdump \t\tsniff dns requests via tcpdump\n"
 	printf " --force-update \t\tforce an update\n" 
 	printf " --force-reset \t\tforce a reset\n"
-        printf " --install-bindhosts-app \t\tBindHosts-app installation\n"
-        printf " --bindhosts-app-uninstall \t\tBindHosts-app uninstallation\n"
 	printf " --custom-cron \t\tcustom update schedule\n"
 	printf "\t\t\tif you do NOT know this, use --enable-cron\n"
 	printf " --enable-cron \t\tenables scheduled updates (10AM daily)\n"
@@ -508,8 +481,6 @@ case "$1" in
 	--tcpdump) tcpdump; exit ;;
 	--force-update) run; exit ;;
 	--force-reset) reset; exit ;;
-        --install-bindhosts-app) bindhosts_app; exit ;;
-        --bindhosts-app-uninstall) bindhosts_app_uninstall; exit ;;
 	--custom-cron) custom_cron "$@"; exit ;;
 	--enable-cron) enable_cron; exit ;;
 	--disable-cron) disable_cron; exit ;;

--- a/module/bindhosts.sh
+++ b/module/bindhosts.sh
@@ -461,13 +461,40 @@ tcpdump () {
 	fi
 }
 
+bindhosts_app () {
+        echo "[+] Installing BindHosts-app..."
+        
+        # Check if the script exists before running it
+        if [ -f "/data/adb/modules/bindhosts/bindhosts-app.sh" ]; then
+        	su -c "sh /data/adb/modules/bindhosts/bindhosts-app.sh"
+        else
+        	echo "[-] bindhosts-app.sh not found!"
+        fi
+}
+
+bindhosts_app_uninstall () {
+        echo "[+] Checking if the package 'me.itejo443.bindhosts' is installed..."
+        echo "[!] If you don't have devpts hooks, then please uninstall manually ..."
+
+        # Check if the package is installed
+        if pm list packages | grep -q "me.itejo443.bindhosts"; then
+        	echo "[+] Package found. Uninstalling..."
+        	# Uninstall the package
+        	su -c "pm uninstall me.itejo443.bindhosts"
+        else
+        	echo "[-] Package 'me.itejo443.bindhosts' not found. Skipping..."
+        fi
+}
+
 show_help () {
 	echo "[%] $( grep '^description=' $MODDIR/module.prop | sed 's/description=//' )"
 	echo "usage:"
 	printf " --action \t\tsimulate action.sh\n"
 	printf " --tcpdump \t\tsniff dns requests via tcpdump\n"
-	printf " --force-update \tforce an update\n" 
-	printf " --force-reset \t\tforce a reset\n" 
+	printf " --force-update \t\tforce an update\n" 
+	printf " --force-reset \t\tforce a reset\n"
+        printf " --install-bindhosts-app \t\tBindHosts-app installation\n"
+        printf " --bindhosts-app-uninstall \t\tBindHosts-app uninstallation\n"
 	printf " --custom-cron \t\tcustom update schedule\n"
 	printf "\t\t\tif you do NOT know this, use --enable-cron\n"
 	printf " --enable-cron \t\tenables scheduled updates (10AM daily)\n"
@@ -481,6 +508,8 @@ case "$1" in
 	--tcpdump) tcpdump; exit ;;
 	--force-update) run; exit ;;
 	--force-reset) reset; exit ;;
+        --install-bindhosts-app) bindhosts_app; exit ;;
+        --bindhosts-app-uninstall) bindhosts_app_uninstall; exit ;;
 	--custom-cron) custom_cron "$@"; exit ;;
 	--enable-cron) enable_cron; exit ;;
 	--disable-cron) disable_cron; exit ;;

--- a/module/customize.sh
+++ b/module/customize.sh
@@ -10,6 +10,51 @@ versionCode=$(grep versionCode $MODPATH/module.prop | sed 's/versionCode=//g' )
 echo "[+] bindhosts v$versionCode "
 echo "[%] customize.sh "
 
+# Install App Section
+echo "[?] Press Volume UP to skip."
+echo "[+] Installing BindHosts-app, Ref:github.com/itejo443/BindHosts-app"
+
+# Function to detect key press (Volume Up or Volume Down) or timeout
+detect_key_press() {
+    timeout_seconds=6  # Modify this to change the wait time
+
+    echo "[+] Waiting for (Volume Up or Down) OR for $timeout_seconds seconds..."
+
+    # Read input with timeout using a pipe and capture the exit code
+    read -r -t $timeout_seconds line < <(getevent -ql)
+
+    # Check if input was read or timed out
+    if [[ $? -eq 142 ]]; then  # Timeout exit code
+        echo "[!] No key pressed within $timeout_seconds seconds. Installing Bindhosts-app"
+        return 0
+    fi
+
+    # Process key press based on the detected input
+    if echo "$line" | grep -q "KEY_VOLUMEUP"; then
+        echo "[+] Volume Up detected. Skipping installation..."
+        return 1  # Skip installation
+    elif echo "$line" | grep -q "KEY_VOLUMEDOWN"; then
+        echo "[+] Volume Down detected. Proceeding with installation..."
+        return 0  # Installing Bindhosts-app
+    fi
+
+    # Handle unexpected input
+    echo "[!] Unrecognized key press. Installing Bindhosts-app"
+    return 0
+}
+
+# Run the function and perform action based on key press
+if detect_key_press; then
+    echo "[+] Installing BindHosts-app..."
+    sh $MODPATH/bindhosts-app.sh
+else
+    # No key pressed or unexpected key, skip installation
+    echo "[!] Skipping installation of BindHosts-app"
+fi
+
+# Continue with other operations below...
+echo "[+] Continuing with other operations..."
+
 # persistence
 [ ! -d $PERSISTENT_DIR ] && mkdir -p $PERSISTENT_DIR
 # make our hosts file dir

--- a/module/uninstall.sh
+++ b/module/uninstall.sh
@@ -10,4 +10,7 @@ rm /data/adb/ksu/bin/bindhosts
 # znhr
 [ -f /data/adb/hostsredirect/hosts ] && printf "127.0.0.1 localhost\n::1 localhost\n" > /data/adb/hostsredirect/hosts
 
+# uninstall bindhosts app if installed
+pm path "$APP_PACKAGE" > /dev/null 2>&1 && pm uninstall me.itejo443.bindhosts
+
 # EOF


### PR DESCRIPTION
### Tile Shortcut in Android Quickpanel
- This will be in sync with action.sh script
- Tileapp installation can be skipped 
 - Alternatively Reload Tile Status, Notification Post from SharedPreferences or by Clicking on Notification Post

**Cons:**
- In compatible (tile status updation) with adaway (adaway has already tile, adaway users should avoid install bindhost-tileapp

**Dropped**
 - Auto update tile status irrespective wherever we run action.sh script (via tile or ksu app or webui etc) 

**For maintainers:**
- if any script was updated .. action.sh, service.sh and bindhost.sh, the tile service code also need to be cross verified.
- tileapp should not be signed with kernelsu keystore

reference module : https://github.com/itejo443/bindhosts/releases/tag/v1.8.6
