### PR TITLE
workflow: manually trigger releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,66 +9,70 @@ on:
       - 'module/**'
       - 'update.json'
   workflow_dispatch:
+    inputs:
+      create_release:
+        description: 'Create a new release?'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 2
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
 
-    - name: Set variables
-      id: setup
-      run: |
-        COMMIT_ID=$(git rev-parse --short HEAD)
-        CURRENT_VERSION_CODE=$(jq -r .versionCode update.json)
-        PREVIOUS_VERSION_CODE=$(jq -r .versionCode <(git show HEAD~1:update.json))
-        VERSION=$(jq -r .version update.json)
+      - name: Set variables
+        id: setup
+        run: |
+          REPO_NAME=$(echo "${{ github.repository }}" | cut -d '/' -f2)
+          COMMIT_ID=$(git rev-parse --short HEAD)
+          VERSION=$(jq -r .version update.json)
+          ZIP_NAME=$REPO_NAME-$COMMIT_ID
+          RELEASE_ZIP=$REPO_NAME
+          MODULE_PATH="$(pwd)/module/"
+          if [ -z "${{ github.event.inputs.create_release }}" ]; then
+            CREATE_RELEASE=false
+          else
+            CREATE_RELEASE=${{ github.event.inputs.create_release }}
+          fi
+          
+          echo "REPO_NAME=${REPO_NAME}" >> $GITHUB_ENV
+          echo "COMMIT_ID=${COMMIT_ID}" >> $GITHUB_ENV
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "ZIP_NAME=${ZIP_NAME}" >> $GITHUB_ENV
+          echo "RELEASE_ZIP=${RELEASE_ZIP}" >> $GITHUB_ENV
+          echo "MODULE_PATH=$MODULE_PATH" >> $GITHUB_ENV
+          echo "CREATE_RELEASE=${CREATE_RELEASE}" >> $GITHUB_ENV
 
-        echo "COMMIT_ID=$COMMIT_ID"
-        echo "CURRENT_VERSION_CODE=$CURRENT_VERSION_CODE"
-        echo "PREVIOUS_VERSION_CODE=$PREVIOUS_VERSION_CODE"
-        echo "VERSION=$VERSION"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ZIP_NAME }}
+          path: ${{ env.MODULE_PATH }}**
 
-        echo "COMMIT_ID=$COMMIT_ID" >> $GITHUB_ENV
-        echo "CURRENT_VERSION_CODE=$CURRENT_VERSION_CODE" >> $GITHUB_ENV
-        echo "PREVIOUS_VERSION_CODE=$PREVIOUS_VERSION_CODE" >> $GITHUB_ENV
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
-        
-        if [ "$CURRENT_VERSION_CODE" -gt "$PREVIOUS_VERSION_CODE" ]; then
-          echo "version_changed=true" >> $GITHUB_ENV
-          echo "ZIP_NAME=bindhosts" >> $GITHUB_ENV
-        else
-          echo "version_changed=false" >> $GITHUB_ENV
-          echo "ZIP_NAME=bindhosts_$CURRENT_VERSION_CODE-$COMMIT_ID" >> $GITHUB_ENV
-        fi
+      - name: Compressing files
+        if: ${{ env.CREATE_RELEASE == 'true' }}
+        run: |
+          echo "Compressing files..."
+          zip -r ${{ env.RELEASE_ZIP }}.zip ${{ env.MODULE_PATH }}**
+          echo "Created zip file: ${{ env.RELEASE_ZIP }}.zip"
 
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.ZIP_NAME }}
-        path: module/
-
-    - name: Compressing files
-      if: env.version_changed == 'true'
-      run: |
-        echo "Compressing files..."
-        cd module/
-        zip -r "${{ env.ZIP_NAME }}" *
-        mv *.zip ../
-        echo "Created zip file: ${{ env.ZIP_NAME }}"
-
-    - name: Create release
-      if: env.version_changed == 'true'
-      uses: softprops/action-gh-release@v2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        files: ${{ env.ZIP_NAME }}.zip
-        tag_name: "${{ env.VERSION }}"
-        name: "Release ${{ env.VERSION }}"
-        body_path: CHANGELOG.md
-        draft: false
-        prerelease: false
+      - name: Create release
+        if: ${{ env.CREATE_RELEASE == 'true' }}
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: "${{ env.RELEASE_ZIP }}.zip"
+          tag_name: "${{ env.VERSION }}"
+          name: "Release ${{ env.VERSION }}"
+          body_path: CHANGELOG.md
+          draft: false
+          prerelease: false


### PR DESCRIPTION
Now all releases need to be manually triggered,  
If the version hasn't changed and a release is triggered, it will replace the module zip file in the pre-existing release of the same tag with the new one.